### PR TITLE
Remove dependency on transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ useMousePosition className =
           render pos
     }
   where
-    name = genComponentName { skipFrames: 2 }
+    name = uniqueNameFromCurrentCallStack { skipFrames: 2 }
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ useMousePosition className =
 ### Examples
 
 There are some examples in the [examples](https://github.com/collegevine/purescript-elmish-hooks/tree/main/examples) folder, which can be seen live [here](https://collegevine.github.io/purescript-elmish-hooks).
+
+### Documentation
+
+Documentation is [published on Pursuit](https://pursuit.purescript.org/packages/purescript-elmish-hooks).

--- a/examples/src/Examples/UseMouseMove.purs
+++ b/examples/src/Examples/UseMouseMove.purs
@@ -7,8 +7,7 @@ import Prelude
 import Data.Maybe (Maybe(..))
 import Elmish (ReactElement, mkEffectFn1, (<|))
 import Elmish.HTML.Styled as H
-import Elmish.Hooks (Hook, mkHook, withHooks)
-import Elmish.Hooks.Type (genComponentName)
+import Elmish.Hooks (Hook, mkHook, uniqueNameFromCurrentCallStack, withHooks)
 import Unsafe.Coerce (unsafeCoerce)
 import Web.HTML.HTMLElement (HTMLElement, getBoundingClientRect)
 
@@ -55,4 +54,4 @@ useMousePosition className =
           render pos
     }
   where
-    name = genComponentName { skipFrames: 2 }
+    name = uniqueNameFromCurrentCallStack { skipFrames: 2 }

--- a/spago.dhall
+++ b/spago.dhall
@@ -19,7 +19,6 @@ to generate this file without the comments in this block.
   , "elmish"
   , "prelude"
   , "psci-support"
-  , "transformers"
   , "tuples"
   ]
 , packages = ./packages.dhall

--- a/src/Elmish/Hooks.purs
+++ b/src/Elmish/Hooks.purs
@@ -12,20 +12,11 @@
 -- |   pure $ H.fragment $ todoView <$> todos
 -- | ```
 module Elmish.Hooks
-  ( withHooks
-  , module Type
+  ( module Type
   , module UseEffect
   , module UseState
   ) where
 
-import Prelude
-
-import Control.Monad.Cont (runCont)
-import Elmish (ReactElement)
-import Elmish.Hooks.Type (Hook, mkHook, genComponentName) as Type
+import Elmish.Hooks.Type (Hook, mkHook, uniqueNameFromCurrentCallStack, withHooks) as Type
 import Elmish.Hooks.UseEffect (useEffect) as UseEffect
 import Elmish.Hooks.UseState (useState) as UseState
-
--- | Unwraps a `Hook ReactElement`
-withHooks :: Type.Hook ReactElement -> ReactElement
-withHooks hooks = runCont hooks identity

--- a/src/Elmish/Hooks/Type.js
+++ b/src/Elmish/Hooks/Type.js
@@ -1,6 +1,6 @@
 const uuidV5 = require('uuid/v5')
 
-const genStableUUID_ = ({ trace }) => ({ skipFrames }) => {
+const uniqueNameFromCurrentCallStack_ = ({ trace }) => ({ skipFrames }) => {
   const stack = new Error().stack
   const stackLines = stack.split('\n')
   // TODO: Add tests to ensure this stays correct: See
@@ -16,5 +16,5 @@ const genStableUUID_ = ({ trace }) => ({ skipFrames }) => {
   return uuidV5(hookCallSite, '31877c6f-998d-44e6-99e6-3cd31a643f1d')
 }
 
-exports.genStableUUID_ = genStableUUID_({ trace: false })
-exports.genStableUUIDWithTrace_ = genStableUUID_({ trace: true })
+exports.uniqueNameFromCurrentCallStack_ = uniqueNameFromCurrentCallStack_({ trace: false })
+exports.uniqueNameFromCurrentCallStackTraced_ = uniqueNameFromCurrentCallStack_({ trace: true })

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -89,7 +89,13 @@ mkHook :: forall msg state a. ComponentName -> ((a -> ReactElement) -> Component
 mkHook name mkDef =
   Hook \render -> wrapWithLocalState name mkDef render
 
--- | Unwraps a `Hook ReactElement`
+-- | Unwraps a `Hook ReactElement`, which is usually created by using one or
+-- | more hooks and then using `pure` to encapsulate a `ReactElement`. E.g.:
+-- |
+-- | view :: ReactElement
+-- | view = withHooks do
+-- |   name /\ setName <- useState ""
+-- |   pure $ H.input_ "" { value: name, onChange: setName <?| eventTargetValue }
 withHooks :: Hook ReactElement -> ReactElement
 withHooks (Hook hook) = hook identity
 

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -4,8 +4,7 @@ module Elmish.Hooks.Type
   , uniqueNameFromCurrentCallStack
   , uniqueNameFromCurrentCallStackTraced
   , withHooks
-  )
-  where
+  ) where
 
 import Prelude
 

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -65,7 +65,7 @@ instance Monad Hook
 -- | ```purs
 -- | myHook x = \y z -> mkHook …
 -- |   where
--- |     name = …
+-- |     name = uniqueNameFromCurrentCallStack { skipFrames: 2 }
 -- |
 -- | This ensures that the number of frames to skip is predictably 2. If
 -- | defining the function differently, a different number of frames can be

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -46,6 +46,8 @@ instance Applicative Hook where
 instance Bind Hook where
   bind (Hook hookA) k = Hook \render ->
     hookA \a -> case k a of Hook hookB -> hookB \b -> render b
+    
+instance Monad Hook
 
 -- | Given a `ComponentName` and a function to create a `ComponentDef` (from a
 -- | render function `a -> ReactElement`), `mkHook` creates a `Hook a`. The name

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -1,13 +1,14 @@
 module Elmish.Hooks.Type
   ( Hook
-  , genComponentName
-  , genComponentNameWithTrace
   , mkHook
-  ) where
+  , uniqueNameFromCurrentCallStack
+  , uniqueNameFromCurrentCallStackTraced
+  , withHooks
+  )
+  where
 
 import Prelude
 
-import Control.Monad.Cont (Cont, cont)
 import Debug (class DebugWarning)
 import Elmish (ReactElement, ComponentDef)
 import Elmish.Component (ComponentName(..), wrapWithLocalState)
@@ -31,14 +32,29 @@ import Elmish.Component (ComponentName(..), wrapWithLocalState)
 -- |   foo /\ setFoo <- useState ""
 -- |   pure …
 -- | ```
-type Hook = Cont ReactElement
+newtype Hook a = Hook ((a -> ReactElement) -> ReactElement)
+
+instance Functor Hook where
+  map f (Hook hook) = Hook \render -> hook (render <<< f)
+
+instance Apply Hook where
+  apply (Hook hookF) (Hook hook) = Hook \render ->
+    hookF \f -> hook (render <<< f)
+
+instance Applicative Hook where
+  pure a = Hook \render -> render a
+
+instance Bind Hook where
+  bind (Hook hookA) k = Hook \render ->
+    hookA \a -> case k a of Hook hookB -> hookB \b -> render b
 
 -- | Given a `ComponentName` and a function to create a `ComponentDef` (from a
 -- | render function `a -> ReactElement`), `mkHook` creates a `Hook a`. The name
--- | can be anything, but it’s recommended to use `genComponentName` to create a
--- | unique name based on where the hook is called from in the stack trace.
--- | `genComponentName` accepts a `skipFrames :: Int` argument to indicate how
--- | many frames back it should look for the call site of the hook.
+-- | can be anything, but it’s recommended to use
+-- | `uniqueNameFromCurrentCallStack` to create a unique name based on where the
+-- | hook is called from in the stack trace. `uniqueNameFromCurrentCallStack`
+-- | accepts a `skipFrames :: Int` argument to indicate how many frames back it
+-- | should look for the call site of the hook.
 -- |
 -- | It’s also recommended to create the name in a where clause and make your
 -- | hook a function accepting one argument. Even if your hook takes more than
@@ -46,14 +62,14 @@ type Hook = Cont ReactElement
 -- | function body:
 -- |
 -- | ```purs
--- | myHook x = \y z -> …
+-- | myHook x = \y z -> mkHook …
 -- |   where
 -- |     name = …
 -- |
 -- | This ensures that the number of frames to skip is predictably 2. If
 -- | defining the function differently, a different number of frames can be
--- | passed. `genComponentNameWithTrace` can be used to help find the correct
--- | number.
+-- | passed. `uniqueNameFromCurrentCallStackTraced` can be used to help find the
+-- | correct number.
 -- |
 -- | As an example of how to use `mkHook`, `useEffect` uses it like so:
 -- |
@@ -70,18 +86,22 @@ type Hook = Cont ReactElement
 -- | ```
 mkHook :: forall msg state a. ComponentName -> ((a -> ReactElement) -> ComponentDef msg state) -> Hook a
 mkHook name mkDef =
-  cont \render -> wrapWithLocalState name mkDef render
+  Hook \render -> wrapWithLocalState name mkDef render
+
+-- | Unwraps a `Hook ReactElement`
+withHooks :: Hook ReactElement -> ReactElement
+withHooks (Hook hook) = hook identity
 
 -- | Generates a `ComponentName` to be passed to `mkHook`.
-genComponentName :: { skipFrames :: Int } -> ComponentName
-genComponentName = ComponentName <<< genStableUUID_
+uniqueNameFromCurrentCallStack :: { skipFrames :: Int } -> ComponentName
+uniqueNameFromCurrentCallStack = ComponentName <<< uniqueNameFromCurrentCallStack_
 
 -- | Generates a `ComponentName` to be passed to `mkHook`, like
--- | `genComponentName`, but logs the stack trace and specific line to the
--- | console.
-genComponentNameWithTrace :: DebugWarning => { skipFrames :: Int } -> ComponentName
-genComponentNameWithTrace = ComponentName <<< genStableUUIDWithTrace_
+-- | `uniqueNameFromCurrentCallStack`, but logs the stack trace and specific
+-- | line to the console.
+uniqueNameFromCurrentCallStackTraced :: DebugWarning => { skipFrames :: Int } -> ComponentName
+uniqueNameFromCurrentCallStackTraced = ComponentName <<< uniqueNameFromCurrentCallStackTraced_
 
-foreign import genStableUUID_ :: { skipFrames :: Int } -> String
+foreign import uniqueNameFromCurrentCallStack_ :: { skipFrames :: Int } -> String
 
-foreign import genStableUUIDWithTrace_ :: { skipFrames :: Int } -> String
+foreign import uniqueNameFromCurrentCallStackTraced_ :: { skipFrames :: Int } -> String

--- a/src/Elmish/Hooks/UseEffect.purs
+++ b/src/Elmish/Hooks/UseEffect.purs
@@ -6,7 +6,7 @@ import Prelude
 
 import Effect.Aff (Aff)
 import Elmish (forkVoid)
-import Elmish.Hooks.Type (Hook, genComponentName, mkHook)
+import Elmish.Hooks.Type (Hook, mkHook, uniqueNameFromCurrentCallStack)
 
 -- | The `useEffect` hook takes an effect (`Aff`) to run and runs it in the
 -- | `init` of the resulting component. E.g.:
@@ -30,4 +30,4 @@ useEffect init =
     , view: \_ _ -> render unit
     }
   where
-    name = genComponentName { skipFrames: 2 }
+    name = uniqueNameFromCurrentCallStack { skipFrames: 2 }

--- a/src/Elmish/Hooks/UseState.purs
+++ b/src/Elmish/Hooks/UseState.purs
@@ -7,7 +7,7 @@ import Prelude
 import Data.Tuple (curry)
 import Data.Tuple.Nested (type (/\))
 import Elmish (Dispatch)
-import Elmish.Hooks.Type (Hook, genComponentName, mkHook)
+import Elmish.Hooks.Type (Hook, mkHook, uniqueNameFromCurrentCallStack)
 
 -- | The `useState` hook takes an initial state and returns a `Hook`
 -- | encapsulating the current state and a `setState` function. E.g.:
@@ -32,4 +32,4 @@ useState initialState =
     , view: curry render
     }
   where
-    name = genComponentName { skipFrames: 2 }
+    name = uniqueNameFromCurrentCallStack { skipFrames: 2 }


### PR DESCRIPTION
It seems like now that we don’t have a monad transformer stack (since we don’t need `WriterT`) we shouldn’t need to rely on the `transformers` package anymore. This implements the Hook monad from scratch and removes the dependency. It also addresses one of the comments from #3, renaming the `genComponentName` function to `uniqueNameFromCurrentCallStack`.