### PR TITLE
Add useRef hook

### DIFF
--- a/examples/spago.dhall
+++ b/examples/spago.dhall
@@ -3,5 +3,5 @@ let config = ../spago.dhall
 
 in config // {
   sources = [ "../src/**/*.purs", "../test/**/*.purs", "./src/**/*.purs" ],
-  dependencies = config.dependencies # [ "elmish-html", "foreign", "maybe", "unsafe-coerce", "web-html", "web-storage" ]
+  dependencies = config.dependencies # [ "elmish-html", "foldable-traversable", "foreign", "unsafe-coerce", "web-html", "web-storage" ]
 }

--- a/examples/src/Examples/UseMouseMove.purs
+++ b/examples/src/Examples/UseMouseMove.purs
@@ -21,7 +21,7 @@ view =
     , H.code "" "mkHook"
     , H.text " to make a custom hook."
     ]
-  , H.div_ "w-100 py-6 rounded bg-light border position-relative"
+  , H.div_ "w-100 py-6 rounded bg-light border position-relative overflow-hidden"
       { style: H.css { height: 200, cursor: "none" } }$
         withHooks do
           pos <- useMousePosition "position-absolute h-100 w-100"

--- a/examples/src/Examples/UseRef.purs
+++ b/examples/src/Examples/UseRef.purs
@@ -1,0 +1,34 @@
+module Examples.UseRef
+  ( view
+  ) where
+
+import Prelude
+
+import Data.Foldable (traverse_)
+import Data.Maybe (Maybe(..))
+import Elmish (ReactElement)
+import Elmish.HTML.Styled as H
+import Elmish.Hooks (withHooks)
+import Elmish.Hooks.UseRef (readRef, useRef)
+import Unsafe.Coerce (unsafeCoerce)
+import Web.HTML.HTMLElement (focus)
+
+view :: ReactElement
+view = withHooks do
+  inputEl <- useRef Nothing
+  let onButtonClick = traverse_ focus =<< readRef inputEl
+  pure $
+    H.div "row mt-3"
+    [ H.div "col-12 col-md-6 col-lg-4"
+      [ H.h2 ""
+        [ H.code "" "useRef"
+        , H.text " hook"
+        ]
+      , H.div "row"
+        [ H.div "col" $
+            H.input_ "form-control" { ref: unsafeCoerce inputEl, defaultValue: "" }
+        , H.div "col-auto" $
+            H.button_ "btn btn-primary" { onClick: onButtonClick } "Focus the input"
+        ]
+      ]
+    ]

--- a/examples/src/Main.purs
+++ b/examples/src/Main.purs
@@ -13,6 +13,7 @@ import Examples.UseEffect as UseEffect
 import Examples.UseEffectPrime as UseEffectPrime
 import Examples.UseLocalStorage as UseLocalStorage
 import Examples.UseMouseMove as UseMouseMove
+import Examples.UseRef as UseRef
 import Examples.UseState as UseState
 
 main :: Effect Unit
@@ -37,6 +38,7 @@ view _ _ =
   , H.hr "my-4"
   , UseEffect.view
   , UseEffectPrime.view
+  , UseRef.view
   , H.hr "my-4"
   , H.h2 "" "Custom hooks"
   , UseLocalStorage.view

--- a/examples/src/Main.purs
+++ b/examples/src/Main.purs
@@ -37,7 +37,9 @@ view _ _ =
   , UseState.view
   , H.hr "my-4"
   , UseEffect.view
+  , H.hr "my-4"
   , UseEffectPrime.view
+  , H.hr "my-4"
   , UseRef.view
   , H.hr "my-4"
   , H.h2 "" "Custom hooks"

--- a/spago.dhall
+++ b/spago.dhall
@@ -18,6 +18,7 @@ to generate this file without the comments in this block.
   , "effect"
   , "elmish"
   , "maybe"
+  , "nullable"
   , "prelude"
   , "psci-support"
   , "tuples"

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -4,7 +4,8 @@ module Elmish.Hooks.Type
   , uniqueNameFromCurrentCallStack
   , uniqueNameFromCurrentCallStackTraced
   , withHooks
-  ) where
+  )
+  where
 
 import Prelude
 

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -4,8 +4,7 @@ module Elmish.Hooks.Type
   , uniqueNameFromCurrentCallStack
   , uniqueNameFromCurrentCallStackTraced
   , withHooks
-  )
-  where
+  ) where
 
 import Prelude
 

--- a/src/Elmish/Hooks/UseRef.js
+++ b/src/Elmish/Hooks/UseRef.js
@@ -1,0 +1,5 @@
+exports.newRef_ = x => ({ current: x })
+
+exports.readRef_ = ref => ref.current
+
+exports.writeRef_ = (ref, a) => { ref.current = a }

--- a/src/Elmish/Hooks/UseRef.purs
+++ b/src/Elmish/Hooks/UseRef.purs
@@ -1,0 +1,77 @@
+module Elmish.Hooks.UseRef
+  ( Ref
+  , readRef
+  , traced
+  , useRef
+  , writeRef
+  )
+  where
+
+import Prelude
+
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toNullable)
+import Data.Nullable as Nullable
+import Debug (class DebugWarning)
+import Effect (Effect)
+import Effect.Uncurried (EffectFn2, runEffectFn1, runEffectFn2)
+import Elmish (ComponentDef, EffectFn1, withTrace)
+import Elmish.Component (ComponentName)
+import Elmish.Hooks.Type (Hook, mkHook, uniqueNameFromCurrentCallStack, uniqueNameFromCurrentCallStackTraced)
+
+-- | The `useRef` hook takes a value and returns a `Hook` encapsulating a
+-- | mutable `Ref`, initialized to that value. E.g.:
+-- |
+-- | ```pursview :: ReactElement
+-- | view = withHooks do
+-- |   inputEl <- useRef Nothing
+-- |   let onButtonClick = traverse_ focus =<< readRef inputEl
+-- |   pure $
+-- |     H.fragment
+-- |     [ H.input_ "form-control" { ref: unsafeCoerce inputEl, defaultValue: "" }
+-- |     , H.button_ "btn btn-primary" { onClick: onButtonClick } "Focus the input"
+-- |     ]
+-- | ```
+useRef :: forall a. Maybe a -> Hook (Ref a)
+useRef a = useRef' name identity a
+  where
+    name = uniqueNameFromCurrentCallStack { skipFrames: 3 }
+
+-- | A version of `useRef` that logs messages, state changes, render times, and
+-- | info from the name-generating function. Intended to be used with qualified
+-- | imports: `UseRef.traced`.
+traced :: forall a. DebugWarning => Maybe a -> Hook (Ref a)
+traced a = useRef' name withTrace a
+  where
+    name = uniqueNameFromCurrentCallStackTraced { skipFrames: 3 }
+
+useRef' :: forall a.
+  ComponentName
+  -> (ComponentDef (Ref a) (Ref a) -> ComponentDef (Ref a) (Ref a))
+  -> Maybe a
+  -> Hook (Ref a)
+useRef' name f a =
+  mkHook name \render -> f
+    { init: pure $ newRef a
+    , update: \_ ref -> pure ref
+    , view: \ref _ -> render ref
+    }
+
+foreign import data Ref :: Type -> Type
+
+-- | Reads the current value of a mutable `Ref`.
+readRef :: forall a. Ref a -> Effect (Maybe a)
+readRef = map Nullable.toMaybe <<< runEffectFn1 readRef_
+
+-- | Updates the value of a mutable `Ref`.
+writeRef :: forall a. Ref a -> Maybe a -> Effect Unit
+writeRef ref = runEffectFn2 writeRef_ ref <<< toNullable
+
+newRef :: forall a. Maybe a -> Ref a
+newRef = newRef_ <<< toNullable
+
+foreign import readRef_ :: forall a. EffectFn1 (Ref a) (Nullable a)
+
+foreign import writeRef_ :: forall a. EffectFn2 (Ref a) (Nullable a) Unit
+
+foreign import newRef_ :: forall a. Nullable a -> Ref a


### PR DESCRIPTION
Adds a new hook: `useRef` that returns a mutable reference that can be passed as a `ref` prop to a React component.

![Jan-02-2022 20-44-41](https://user-images.githubusercontent.com/23478119/147894850-0d68e307-19f8-42bb-b078-9a4325a7d4c8.gif)
