### PR TITLE
Allow continuation-passing style

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ useMousePosition className =
 
 ### Continuation-Passing Style
 
-You can use CPS using the `withHook` or `withHookCurried` functions, or their respective operators (`==>` and `=/>`).
+If you're only using a single hook, sometimes it might be more concise to use CPS via the `==>` or `=/>` operators.
 
 ```purs
 myInput :: ReactElement

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ useMousePosition className =
     name = uniqueNameFromCurrentCallStack { skipFrames: 2 }
 ```
 
+### Continuation-Passing Style
+
+You can use CPS using the `withHook` or `withHookCurried` functions, or their respective operators (`==>` and `=/>`).
+
+```purs
+myInput :: ReactElement
+myInput = useState "" =/> \name setName ->
+  H.input_ "" { value: name, onChange: setName <?| eventTargetValue }
+```
+
 ### Examples
 
 There are some examples in the [examples](https://github.com/collegevine/purescript-elmish-hooks/tree/main/examples) folder, which can be seen live [here](https://collegevine.github.io/purescript-elmish-hooks).

--- a/examples/src/Examples/UseState.purs
+++ b/examples/src/Examples/UseState.purs
@@ -4,37 +4,35 @@ module Examples.UseState
 
 import Prelude
 
-import Data.Tuple.Nested ((/\))
 import Elmish (ReactElement)
 import Elmish.HTML.Styled as H
-import Elmish.Hooks (useState, withHooks)
+import Elmish.Hooks (useState)
+import Elmish.Hooks.Type ((=/>))
 
 view :: ReactElement
-view = withHooks do
-  visible /\ setVisible <- useState false
-  pure $
-    H.div ""
-    [ H.h2 ""
-      [ H.code "" "useState"
-      , H.text " hook"
-      ]
-    , H.button_ "btn btn-primary" { onClick: setVisible $ not visible } "Show"
-    , if visible then
-        H.fragment
-        [ H.div_ "modal fade show d-block" { style: H.css { pointerEvents: "none" } } $
-            H.div "modal-dialog" $
-              H.div "modal-content" $
-                H.div "modal-body"
-                [ H.div "row"
-                  [ H.div "col" $
-                      H.h3 "header-title" "Modal"
-                  , H.div "col-auto" $
-                      H.button_ "btn btn-icon btn-lg p-0 text-muted" { onClick: setVisible false } "×"
-                  ]
-                , H.div "py-4" "Content"
-                ]
-        , H.div_ "modal-backdrop fade show" { onClick: setVisible false } H.empty
-        ]
-      else
-        H.empty
+view = useState false =/> \visible setVisible ->
+  H.div ""
+  [ H.h2 ""
+    [ H.code "" "useState"
+    , H.text " hook"
     ]
+  , H.button_ "btn btn-primary" { onClick: setVisible $ not visible } "Show"
+  , if visible then
+      H.fragment
+      [ H.div_ "modal fade show d-block" { style: H.css { pointerEvents: "none" } } $
+          H.div "modal-dialog" $
+            H.div "modal-content" $
+              H.div "modal-body"
+              [ H.div "row"
+                [ H.div "col" $
+                    H.h3 "header-title" "Modal"
+                , H.div "col-auto" $
+                    H.button_ "btn btn-icon btn-lg p-0 text-muted" { onClick: setVisible false } "×"
+                ]
+              , H.div "py-4" "Content"
+              ]
+      , H.div_ "modal-backdrop fade show" { onClick: setVisible false } H.empty
+      ]
+    else
+      H.empty
+  ]

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -127,7 +127,6 @@ infixl 1 withHook as ==>
 -- | Given a `Hook (a /\ b)`, this allows invoking it with a curried `render`
 -- | callback.
 -- |
--- | ```purs
 -- | Intended to be used via the `=/>` operator:
 -- |
 -- | ```purs

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -135,7 +135,7 @@ infixl 1 withHook as ==>
 -- |
 -- | ```purs
 -- | view :: ReactElement
--- | view = withHook (useState "") \name setName ->
+-- | view = withHookCurried (useState "") \name setName ->
 -- |   H.input_ "" { value: name, onChange: setName <?| eventTargetValue }
 -- | ```
 -- |

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -112,13 +112,7 @@ withHooks (Hook hook) = hook identity
 -- | continuation-passing style. This helper makes that easier, accepting a
 -- | `render` callback.
 -- |
--- | ```purs
--- | view :: ReactElement
--- | view = withHook (useState "") \(name /\ setName) ->
--- |   H.input_ "" { value: name, onChange: setName <?| eventTargetValue }
--- | ```
--- |
--- | Or using the operator:
+-- | Intended to be used via the `==>` operator:
 -- |
 -- | ```purs
 -- | view :: ReactElement
@@ -134,12 +128,7 @@ infixl 1 withHook as ==>
 -- | callback.
 -- |
 -- | ```purs
--- | view :: ReactElement
--- | view = withHookCurried (useState "") \name setName ->
--- |   H.input_ "" { value: name, onChange: setName <?| eventTargetValue }
--- | ```
--- |
--- | Or using the operator:
+-- | Intended to be used via the `=/>` operator:
 -- |
 -- | ```purs
 -- | view :: ReactElement


### PR DESCRIPTION
The example barely changed. Best to ignore whitespace: https://github.com/collegevine/purescript-elmish-hooks/pull/10/files?w=1.