### PR TITLE
Remove unique names from individual hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ foreign import data :: UseMousePosition :: HookType
 
 useMousePosition :: String -> Hook UseMousePosition (Maybe { x :: Number, y :: Number })
 useMousePosition className =
-  mkHook name \render ->
+  mkHook (ComponentName "UseMousePosition") \render ->
     { init: pure Nothing
     , update: \_ pos -> pure pos
     , view: \pos dispatch ->
@@ -72,8 +72,6 @@ useMousePosition className =
           } $
           render pos
     }
-  where
-    name = uniqueNameFromCurrentCallStack { skipFrames: 3, prefix: "UseMousePosition" }
 ```
 
 ### Continuation-Passing Style

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ todos = withHooks Hooks.do
 Custom hooks can also be created. One way is to build on other hooks using the `Hook` monad:
 
 ```purs
-type UseLocalStorage = UseState String <> UseEffect Unit <> Pure
+type UseLocalStorage = UseState String <> UseEffect Unit
 
 useLocalStorage :: String -> String -> Hook UseLocalStorage (String /\ Dispatch String)
 useLocalStorage key defaultValue = Hooks.do

--- a/examples/src/Examples/UseEffect.purs
+++ b/examples/src/Examples/UseEffect.purs
@@ -21,6 +21,13 @@ view = withHooks Hooks.do
     delay $ Milliseconds 2000.0
     liftEffect $ setTodos $ Just ["Do thing", "Do another thing", "Some more stuff"]
 
+  _ <-
+    if true then Hooks.do
+      x <- useState 0
+      Hooks.pure x
+    else
+      useState 0
+
   Hooks.pure $
     H.div "row"
     [ H.div "col-12 col-md-6 col-lg-4"

--- a/examples/src/Examples/UseEffect.purs
+++ b/examples/src/Examples/UseEffect.purs
@@ -21,13 +21,6 @@ view = withHooks Hooks.do
     delay $ Milliseconds 2000.0
     liftEffect $ setTodos $ Just ["Do thing", "Do another thing", "Some more stuff"]
 
-  _ <-
-    if true then Hooks.do
-      x <- useState 0
-      Hooks.pure x
-    else
-      useState 0
-
   Hooks.pure $
     H.div "row"
     [ H.div "col-12 col-md-6 col-lg-4"

--- a/examples/src/Examples/UseLocalStorage.purs
+++ b/examples/src/Examples/UseLocalStorage.purs
@@ -9,7 +9,7 @@ import Data.Tuple.Nested (type (/\), (/\))
 import Effect.Class (liftEffect)
 import Elmish (ReactElement, Dispatch, (<?|))
 import Elmish.HTML.Styled as H
-import Elmish.Hooks (Hook, Pure, UseEffect, UseState, type (<>), useEffect, useState, withHooks)
+import Elmish.Hooks (type (<>), Hook, UseEffect, UseState, useEffect, useState, withHooks)
 import Elmish.Hooks as Hooks
 import Utils (eventTargetValue)
 import Web.HTML (window)
@@ -34,7 +34,7 @@ view = withHooks Hooks.do
       ]
     ]
 
-type UseLocalStorage = UseState String <> UseEffect Unit <> Pure
+type UseLocalStorage = UseState String <> UseEffect Unit
 
 useLocalStorage :: String -> String -> Hook UseLocalStorage (String /\ Dispatch String)
 useLocalStorage key defaultValue = Hooks.do

--- a/examples/src/Examples/UseMouseMove.purs
+++ b/examples/src/Examples/UseMouseMove.purs
@@ -6,8 +6,9 @@ import Prelude
 
 import Data.Maybe (Maybe(..))
 import Elmish (ReactElement, mkEffectFn1, (<|))
+import Elmish.Component (ComponentName(..))
 import Elmish.HTML.Styled as H
-import Elmish.Hooks (Hook, HookType, mkHook, uniqueNameFromCurrentCallStack, withHooks)
+import Elmish.Hooks (Hook, HookType, mkHook, withHooks)
 import Elmish.Hooks as Hooks
 import Unsafe.Coerce (unsafeCoerce)
 import Web.HTML.HTMLElement (HTMLElement, getBoundingClientRect)
@@ -40,7 +41,7 @@ foreign import data UseMousePosition :: HookType
 
 useMousePosition :: String -> Hook UseMousePosition (Maybe { x :: Number, y :: Number })
 useMousePosition className =
-  mkHook name \render ->
+  mkHook (ComponentName "UseMouseMove") \render ->
     { init: pure Nothing
     , update: \_ pos -> pure pos
     , view: \pos dispatch ->
@@ -56,5 +57,3 @@ useMousePosition className =
           } $
           render pos
     }
-  where
-    name = uniqueNameFromCurrentCallStack { skipFrames: 3, prefix: "UseMouseMove" }

--- a/src/Elmish/Hooks.purs
+++ b/src/Elmish/Hooks.purs
@@ -21,6 +21,6 @@ module Elmish.Hooks
   , module UseState
   ) where
 
-import Elmish.Hooks.Type (Hook, HookType, Pure, type (<>), bind, discard, mkHook, pure, uniqueNameFromCurrentCallStack, withHooks, (==>), (=/>)) as Type
+import Elmish.Hooks.Type (Hook, HookType, Pure, type (<>), bind, discard, mkHook, pure, withHooks, (==>), (=/>)) as Type
 import Elmish.Hooks.UseEffect (UseEffect, useEffect) as UseEffect
 import Elmish.Hooks.UseState (UseState, useState) as UseState

--- a/src/Elmish/Hooks/Type.js
+++ b/src/Elmish/Hooks/Type.js
@@ -1,21 +1,12 @@
 const stackTraceParser = require('stacktrace-parser')
 
-const uniqueNameFromCurrentCallStack_ = ({ trace }) => ({ skipFrames, prefix }) => {
+exports.uniqueNameFromCurrentCallStack_ = ({ skipFrames, prefix }) => {
   const stack = new Error().stack
   const stackLines = stackTraceParser.parse(stack)
   const hookCallSite = stackLines[skipFrames]
   const file = cleanName(hookCallSite.file.replace(/^(http(s?):\/\/)?[^\/]+/, ''))
   const methodName = cleanName(hookCallSite.methodName)
-  if (trace) {
-    console.log('Hook Call Site:')
-    console.log(hookCallSite)
-    console.log('Full Stack Trace:')
-    console.log(stack)
-  }
   return `${prefix}_${file}_${methodName}_${hookCallSite.lineNumber}_${hookCallSite.column}`
 }
 
 const cleanName = name => name.replace(/[^\d\w]+/g, '_').replace(/(^_|_$)/g, '')
-
-exports.uniqueNameFromCurrentCallStack_ = uniqueNameFromCurrentCallStack_({ trace: false })
-exports.uniqueNameFromCurrentCallStackTraced_ = uniqueNameFromCurrentCallStack_({ trace: true })

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -1,5 +1,5 @@
 module Elmish.Hooks.Type
-  ( class AppendHookTypeClass
+  ( class ComposedHookTypes
   , AppendHookType
   , Hook
   , HookType
@@ -51,11 +51,13 @@ foreign import data AppendHookType :: HookType -> HookType -> HookType
 
 infixr 1 type AppendHookType as <>
 
-class AppendHookTypeClass (left :: HookType) (right :: HookType) (result :: HookType) | left right -> result
+-- | This class represents the type level function for composing `HookType`s,
+-- | with instances for appending the identity and arbitrary `HookType`s.
+class ComposedHookTypes (left :: HookType) (right :: HookType) (result :: HookType) | left right -> result
 
-instance AppendHookTypeClass Pure right right
-else instance AppendHookTypeClass left Pure left
-else instance AppendHookTypeClass left right (left <> right)
+instance ComposedHookTypes Pure right right
+else instance ComposedHookTypes left Pure left
+else instance ComposedHookTypes left right (left <> right)
 
 -- | The type of a hook, e.g. the result of calling `useState`. It turns out
 -- | that hooks can be modeled as a continuation, where the callback function
@@ -93,7 +95,7 @@ instance Functor (Hook t) where
   map f (Hook hook) = Hook \render -> hook (render <<< f)
 
 bind :: forall left right result a b.
-  AppendHookTypeClass left right result
+  ComposedHookTypes left right result
   => Hook left a
   -> (a -> Hook right b)
   -> Hook result b
@@ -102,7 +104,7 @@ bind (Hook hookA) k = Hook \render ->
 
 discard :: forall left right result a b.
   Discard a
-  => AppendHookTypeClass left right result
+  => ComposedHookTypes left right result
   => Hook left a
   -> (a -> Hook right b)
   -> Hook result b

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -43,7 +43,7 @@ import Prelude as Prelude
 -- | need to be used in the same order for the hook types to match.
 foreign import data HookType :: Type
 
--- | The `HookType` of `pure`.
+-- | The `HookType` of `pure` — the identity of the `HookType` monoid.
 foreign import data Pure :: HookType
 
 -- | A type which allows appending two `HookType`s.

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -39,8 +39,8 @@ import Prelude as Prelude
 -- | ```
 -- |
 -- | because the first block has a `HookType` of `UseState String <> UseState
--- | Int <> Pure` and the second is `UseState Int <> UseState String`. The same
--- | hooks need to be used in the same order for the hook types to match.
+-- | Int` and the second is `UseState Int <> UseState String`. The same hooks
+-- | need to be used in the same order for the hook types to match.
 foreign import data HookType :: Type
 
 -- | The `HookType` of `pure`.

--- a/src/Elmish/Hooks/UseEffect.purs
+++ b/src/Elmish/Hooks/UseEffect.purs
@@ -12,8 +12,8 @@ import Data.Maybe (Maybe(..))
 import Debug (class DebugWarning)
 import Effect.Aff (Aff)
 import Elmish (EffectFn1, ComponentDef, createElement, forkVoid, withTrace, (<?|))
-import Elmish.Component (ComponentName)
-import Elmish.Hooks.Type (Hook, HookType, mkHook, uniqueNameFromCurrentCallStack, uniqueNameFromCurrentCallStackTraced)
+import Elmish.Component (ComponentName(..))
+import Elmish.Hooks.Type (Hook, HookType, mkHook)
 import Elmish.React.Import (EmptyProps, ImportedReactComponent, ImportedReactComponentConstructorWithContent)
 import Elmish.Ref (Ref, deref, ref)
 
@@ -34,10 +34,7 @@ foreign import data UseEffect :: Type -> HookType
 -- |   Hooks.pure $ H.fragment $ todoView <$> todos
 -- | ```
 useEffect :: Aff Unit -> Hook (UseEffect Unit) Unit
-useEffect aff =
-  useEffect_ name identity unit $ const aff
-  where
-    name = uniqueNameFromCurrentCallStack { skipFrames: 3, prefix: "UseEffect" }
+useEffect runEffect = useEffect_ (ComponentName "UseEffect") identity unit $ const runEffect
 
 -- | This is like `useEffect`, but allows passing a value which, when it
 -- | changes, will trigger the effect to run again. E.g.:
@@ -53,26 +50,17 @@ useEffect aff =
 -- |   Hooks.pure H.button_ "" { onClick: setCount $ count + 1 } "Click me"
 -- | ```
 useEffect' :: forall a. Eq a => a -> (a -> Aff Unit) -> Hook (UseEffect a) Unit
-useEffect' deps = \runEffect ->
-  useEffect_ name identity deps runEffect
-  where
-    name = uniqueNameFromCurrentCallStack { skipFrames: 3, prefix: "UseEffectPrime" }
+useEffect' deps runEffect = useEffect_ (ComponentName "UseEffectPrime") identity deps runEffect
 
--- | A version of `useEffect` that logs info from the name-generating function.
--- | Intended to be used with qualified imports: `UseEffect.traced`.
+-- | A version of `useEffect` that logs messages, state changes and render
+-- | times. Intended to be used with qualified imports: `UseEffect.traced`.
 traced :: DebugWarning => Aff Unit -> Hook (UseEffect Unit) Unit
-traced runEffect =
-  useEffect_ name withTrace unit $ const runEffect
-  where
-    name = uniqueNameFromCurrentCallStackTraced { skipFrames: 3, prefix: "UseEffect_Traced" }
+traced runEffect = useEffect_ (ComponentName "UseEffect_Traced") withTrace unit $ const runEffect
 
--- | A version of `useEffect'` that logs info from the name-generating function.
--- | Intended to be used with qualified imports: `UseEffect.traced'`.
+-- | A version of `useEffect'` that logs messages, state changes and render
+-- | times. Intended to be used with qualified imports: `UseEffect.traced'`.
 traced' :: forall a. DebugWarning => Eq a => a -> (a -> Aff Unit) -> Hook (UseEffect a) Unit
-traced' deps = \runEffect ->
-  useEffect_ name withTrace deps runEffect
-  where
-    name = uniqueNameFromCurrentCallStackTraced { skipFrames: 3, prefix: "UseEffect_TracedPrime" }
+traced' deps runEffect = useEffect_ (ComponentName "UseEffect_TracedPrime") withTrace deps runEffect
 
 useEffect_ :: forall a.
   Eq a

--- a/src/Elmish/Hooks/UseState.purs
+++ b/src/Elmish/Hooks/UseState.purs
@@ -10,8 +10,8 @@ import Data.Tuple (curry)
 import Data.Tuple.Nested (type (/\))
 import Debug (class DebugWarning)
 import Elmish (ComponentDef, Dispatch, withTrace)
-import Elmish.Component (ComponentName)
-import Elmish.Hooks.Type (Hook, HookType, mkHook, uniqueNameFromCurrentCallStack, uniqueNameFromCurrentCallStackTraced)
+import Elmish.Component (ComponentName(..))
+import Elmish.Hooks.Type (Hook, HookType, mkHook)
 
 foreign import data UseState :: Type -> HookType
 
@@ -31,17 +31,12 @@ foreign import data UseState :: Type -> HookType
 -- |     ]
 -- | ```
 useState :: forall state. state -> Hook (UseState state) (state /\ Dispatch state)
-useState state = useState' name identity state
-  where
-    name = uniqueNameFromCurrentCallStack { skipFrames: 3, prefix: "UseState" }
+useState state = useState' (ComponentName "UseState") identity state
 
--- | A version of `useState` that logs messages, state changes, render times,
--- | and info from the name-generating function. Intended to be used with
--- | qualified imports: `UseState.traced`.
+-- | A version of `useState` that logs messages, state changes and render times.
+-- | Intended to be used with qualified imports: `UseState.traced`.
 traced :: forall state. DebugWarning => state -> Hook (UseState state) (state /\ Dispatch state)
-traced state = useState' name withTrace state
-  where
-    name = uniqueNameFromCurrentCallStackTraced { skipFrames: 3, prefix: "UseState_Traced" }
+traced state = useState' (ComponentName "UseState_Traced") withTrace state
 
 useState' :: forall state.
   ComponentName

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -38,12 +38,6 @@ spec = do
         , H.div "with-hooks-2-parent" $ withHooks component
         , H.div "with-hooks-3-parent" withHooksComponent
         , H.div "with-hooks-4-parent" withHooksComponent
-        , H.div "with-hooks-5-parent" $ withHooks Hooks.do
-            _ <- useState ""
-            Hooks.pure $ H.div "" "content"
-        , H.div "with-hooks-6-parent" $ withHooks Hooks.do
-            _ <- useState ""
-            Hooks.pure $ H.div "" "content"
         ]
 
     describe "withHooks" do
@@ -61,22 +55,6 @@ spec = do
           withHooks4Name <- find ".with-hooks-4-parent" >> childAt 0 >> name
           withHooks3Name `shouldContain` "WithHooks"
           withHooks3Name `shouldEqual` withHooks4Name
-
-    describe "useState" do
-      it "has a unique name when used twice" $
-        testElement wrappedComponent do
-          useState5Name <- find ".with-hooks-5-parent" >> childAt 0 >> childAt 0 >> name
-          useState6Name <- find ".with-hooks-6-parent" >> childAt 0 >> childAt 0 >> name
-          useState5Name `shouldContain` "UseState"
-          useState6Name `shouldContain` "UseState"
-          useState5Name `shouldNotEqual` useState6Name
-
-      it "has the same when same reference used twice" $
-        testElement wrappedComponent do
-          useState1Name <- find ".with-hooks-1-parent" >> childAt 0 >> childAt 0 >> name
-          useState2Name <- find ".with-hooks-2-parent" >> childAt 0 >> childAt 0 >> name
-          useState1Name `shouldContain` "UseState"
-          useState1Name `shouldEqual` useState2Name
 
     describe "withHook" do
       let


### PR DESCRIPTION
This PR does two things:

1. Now that we guarantee hooks of the same type run in the same order within a `withHooks` block, we don’t need unique names for hooks! This gets rid of that for `useState` and `useEffect`. We now only need unique names for the wrapper component created by `withHooks` itself, so we don’t export the helper functions which generate unique names.
2. `HookType` is now a proper type-level monoid, where `Pure` is the identity. Because of this:

### The following now compiles!

![image](https://user-images.githubusercontent.com/23478119/149839479-6a36a276-90f8-4c25-b384-c2ed04badfdd.png)

### And the errors for the other type-unsafe conditional hook chains still look pretty good

#### Swapping order of hooks

![image](https://user-images.githubusercontent.com/23478119/149839181-9626d4c7-c00d-4c61-91af-debbe3597f4e.png)

#### Conditional hook using `when`

![image](https://user-images.githubusercontent.com/23478119/149839232-8995cd98-b078-4b37-a500-7d32c4911c37.png)

#### Conditional hook using `if … else pure unit`

![image](https://user-images.githubusercontent.com/23478119/149839304-c14eb54f-43e5-4147-ba40-ce335afd97f4.png)
