### PR TITLE
Rename `withHooks` -> `component`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 0.7.0
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- **Breaking**: Renamed `withHooks` to `component`.
+
 ## 0.6.1
 
 ### Fixed
 
-- Fix `useRef` docs
+- Fixed `useRef` docs.
 
 ## 0.6.0
 
 ### Added
 
-- `useRef` hook
+- Added `useRef` hook.
 
 ## 0.5.3
 
 ### Added
 
-- `useEffect'` is now reexported from `Elmish.Hooks` for easy access
+- `useEffect'` is now reexported from `Elmish.Hooks` for easy access.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - **Breaking**: Renamed `withHooks` to `component`.
 
 ## 0.6.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This library offers an analog of [React Hooks](https://reactjs.org/docs/hooks-in
 
 ### Getting Started
 
-To use this library, install `elmish-hooks`, as well as the npm package [`stacktrace-parser`](https://github.com/errwischt/stacktrace-parser).
+To use this library, install `elmish-hooks`, as well as the npm package [stacktrace-parser](https://github.com/errwischt/stacktrace-parser).
 
 ```
 npx spago install elmish-hooks

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ npm install stacktrace-parser --save
 
 ### Hooks
 
-Hooks allow introducing local state or effects without writing a new component. This library comes with two builtin hooks: `useState` and `useEffect`:
+Hooks allow introducing local state or effects without writing a new `ComponentDef`. This library comes with three builtin hooks: `useState`, `useEffect`, and `useRef`. Here’s what hooks look like in practice:
 
 ```purs
 todos :: ReactElement
-todos = withHooks Hooks.do
+todos = Hooks.component Hooks.do
   todos /\ setTodos <- useState []
 
   useEffect do
@@ -76,7 +76,7 @@ useMousePosition className =
 
 ### Continuation-Passing Style
 
-If you're only using a single hook, sometimes it might be more concise to use CPS via the `==>` or `=/>` operators.
+If you’re only using a single hook, sometimes it might be more concise to use CPS via the `==>` or `=/>` operators.
 
 ```purs
 myInput :: ReactElement

--- a/examples/src/Examples/UseEffect.purs
+++ b/examples/src/Examples/UseEffect.purs
@@ -10,11 +10,11 @@ import Effect.Aff (Milliseconds(..), delay)
 import Effect.Class (liftEffect)
 import Elmish (ReactElement)
 import Elmish.HTML.Styled as H
-import Elmish.Hooks (useEffect, useState, withHooks)
+import Elmish.Hooks (useEffect, useState)
 import Elmish.Hooks as Hooks
 
 view :: ReactElement
-view = withHooks Hooks.do
+view = Hooks.component Hooks.do
   todos /\ setTodos <- useState Nothing
 
   useEffect do

--- a/examples/src/Examples/UseEffectPrime.purs
+++ b/examples/src/Examples/UseEffectPrime.purs
@@ -8,7 +8,7 @@ import Data.Tuple.Nested ((/\))
 import Effect.Class (liftEffect)
 import Elmish (ReactElement)
 import Elmish.HTML.Styled as H
-import Elmish.Hooks (useState, withHooks)
+import Elmish.Hooks (useState)
 import Elmish.Hooks as Hooks
 import Elmish.Hooks.UseEffect (useEffect')
 import Web.HTML (window)
@@ -16,7 +16,7 @@ import Web.HTML.HTMLDocument as HTMLDocument
 import Web.HTML.Window as Window
 
 view :: ReactElement
-view = withHooks Hooks.do
+view = Hooks.component Hooks.do
   count /\ setCount <- useState 0
 
   useEffect' count \c -> liftEffect do

--- a/examples/src/Examples/UseLocalStorage.purs
+++ b/examples/src/Examples/UseLocalStorage.purs
@@ -9,7 +9,7 @@ import Data.Tuple.Nested (type (/\), (/\))
 import Effect.Class (liftEffect)
 import Elmish (ReactElement, Dispatch, (<?|))
 import Elmish.HTML.Styled as H
-import Elmish.Hooks (type (<>), Hook, UseEffect, UseState, useEffect, useState, withHooks)
+import Elmish.Hooks (type (<>), Hook, UseEffect, UseState, useEffect, useState)
 import Elmish.Hooks as Hooks
 import Utils (eventTargetValue)
 import Web.HTML (window)
@@ -17,7 +17,7 @@ import Web.HTML.Window (localStorage)
 import Web.Storage.Storage (getItem, setItem)
 
 view :: ReactElement
-view = withHooks Hooks.do
+view = Hooks.component Hooks.do
   foo /\ setFoo <- useLocalStorage "foo" ""
   Hooks.pure $
     H.div "row"

--- a/examples/src/Examples/UseMouseMove.purs
+++ b/examples/src/Examples/UseMouseMove.purs
@@ -8,7 +8,7 @@ import Data.Maybe (Maybe(..))
 import Elmish (ReactElement, mkEffectFn1, (<|))
 import Elmish.Component (ComponentName(..))
 import Elmish.HTML.Styled as H
-import Elmish.Hooks (Hook, HookType, mkHook, withHooks)
+import Elmish.Hooks (Hook, HookType, mkHook)
 import Elmish.Hooks as Hooks
 import Unsafe.Coerce (unsafeCoerce)
 import Web.HTML.HTMLElement (HTMLElement, getBoundingClientRect)
@@ -25,7 +25,7 @@ view =
     ]
   , H.div_ "w-100 py-6 rounded bg-light border position-relative overflow-hidden"
       { style: H.css { height: 200, cursor: "none" } }$
-        withHooks Hooks.do
+        Hooks.component Hooks.do
           pos <- useMousePosition "position-absolute h-100 w-100"
           Hooks.pure $ case pos of
             Just { x, y } ->

--- a/examples/src/Examples/UseRef.purs
+++ b/examples/src/Examples/UseRef.purs
@@ -8,14 +8,13 @@ import Data.Foldable (traverse_)
 import Data.Tuple.Nested ((/\))
 import Elmish (ReactElement)
 import Elmish.HTML.Styled as H
-import Elmish.Hooks (withHooks)
+import Elmish.Hooks (useRef)
 import Elmish.Hooks as Hooks
-import Elmish.Hooks.UseRef (useRef)
 import Web.HTML.HTMLElement (focus)
 import Web.HTML.HTMLInputElement as HTMLInputElement
 
 view :: ReactElement
-view = withHooks Hooks.do
+view = Hooks.component Hooks.do
   inputEl /\ inputRef <- useRef
   let onButtonClick = traverse_ (focus <<< HTMLInputElement.toHTMLElement) inputEl
   Hooks.pure $

--- a/src/Elmish/Hooks.purs
+++ b/src/Elmish/Hooks.purs
@@ -2,11 +2,11 @@
 -- | encapsulate state or effects.
 -- |
 -- | ```purs
--- | import Elmish.Hooks (withHooks, useEffect, useState)
+-- | import Elmish.Hooks (useEffect, useState)
 -- | import Elmish.Hooks as Hooks
 -- |
 -- | todos :: ReactElement
--- | todos = withHooks Hooks.do
+-- | todos = Hooks.component Hooks.do
 -- |   todos /\ setTodos <- useState []
 -- |
 -- |   useEffect do
@@ -22,7 +22,7 @@ module Elmish.Hooks
   , module UseState
   ) where
 
-import Elmish.Hooks.Type (Hook, HookType, type (<>), bind, discard, mkHook, pure, withHooks, (==>), (=/>)) as Type
+import Elmish.Hooks.Type (Hook, HookType, type (<>), bind, component, discard, mkHook, pure, (==>), (=/>)) as Type
 import Elmish.Hooks.UseEffect (UseEffect, useEffect, useEffect') as UseEffect
 import Elmish.Hooks.UseRef (UseRef, useRef) as UseRef
 import Elmish.Hooks.UseState (UseState, useState) as UseState

--- a/src/Elmish/Hooks/Type.purs
+++ b/src/Elmish/Hooks/Type.purs
@@ -6,12 +6,12 @@ module Elmish.Hooks.Type
   , Pure
   , type (<>)
   , bind
+  , component
   , discard
   , mkHook
   , pure
   , withHook
   , withHookCurried
-  , withHooks
   , (=/>)
   , (==>)
   ) where
@@ -28,7 +28,7 @@ import Prelude as Prelude
 -- | example, the following will not compile because we track `HookType`:
 -- |
 -- | ```purs
--- | withHooks Hooks.do
+-- | Hooks.component Hooks.do
 -- |   if someCondition then Hooks.do
 -- |     x <- useState ""
 -- |     _ <- useState 0
@@ -84,7 +84,7 @@ else instance ComposedHookTypes l2 right right' => ComposedHookTypes (l1 <> l2) 
 -- | do-notation, which looks a lot like the React hooks syntax:
 -- |
 -- | ```purs
--- | withHooks do
+-- | Hooks.component do
 -- |   foo /\ setFoo <- useState ""
 -- |   pure …
 -- | ```
@@ -95,7 +95,7 @@ else instance ComposedHookTypes l2 right right' => ComposedHookTypes (l1 <> l2) 
 -- | need to use qualified do notation:
 -- |
 -- | ```purs
--- | withHooks Hooks.do
+-- | Hooks.component Hooks.do
 -- |   foo /\ setFoo <- useState ""
 -- |   Hooks.pure …
 -- | ```
@@ -154,17 +154,17 @@ mkHook name mkDef =
 -- |
 -- | ```purs
 -- | view :: ReactElement
--- | view = withHooks Hooks.do
+-- | view = Hooks.component Hooks.do
 -- |   name /\ setName <- useState ""
 -- |   Hooks.pure $ H.input_ "" { value: name, onChange: setName <?| eventTargetValue }
 -- | ```
-withHooks :: forall t. Hook' t ReactElement -> ReactElement
-withHooks hook = withHooks' name hook
+component :: forall t. Hook' t ReactElement -> ReactElement
+component hook = component' name hook
   where
-    name = uniqueNameFromCurrentCallStack { skipFrames: 3, prefix: "WithHooks" }
+    name = uniqueNameFromCurrentCallStack { skipFrames: 3, prefix: "HooksComponent" }
 
-withHooks' :: forall t. ComponentName -> Hook' t ReactElement -> ReactElement
-withHooks' name (Hook hook) =
+component' :: forall t. ComponentName -> Hook' t ReactElement -> ReactElement
+component' name (Hook hook) =
   unit # wrapWithLocalState name \_ ->
     { init: Prelude.pure unit
     , update: const absurd
@@ -183,7 +183,7 @@ withHooks' name (Hook hook) =
 -- |   H.input_ "" { value: name, onChange: setName <?| eventTargetValue }
 -- | ```
 withHook :: forall t a. Hook' t a -> (a -> ReactElement) -> ReactElement
-withHook hook = \render -> withHooks' name $ render <$> hook
+withHook hook = \render -> component' name $ render <$> hook
   where
     name = uniqueNameFromCurrentCallStack { skipFrames: 3, prefix: "WithHook" }
 
@@ -200,7 +200,7 @@ infixl 1 withHook as ==>
 -- |   H.input_ "" { value: name, onChange: setName <?| eventTargetValue }
 -- | ```
 withHookCurried :: forall t a b. Hook' t (a /\ b) -> (a -> b -> ReactElement) -> ReactElement
-withHookCurried hook = \render -> withHooks' name $ (uncurry render) <$> hook
+withHookCurried hook = \render -> component' name $ (uncurry render) <$> hook
   where
     name = uniqueNameFromCurrentCallStack { skipFrames: 3, prefix: "WithHookCurried" }
 

--- a/src/Elmish/Hooks/UseEffect.purs
+++ b/src/Elmish/Hooks/UseEffect.purs
@@ -24,7 +24,7 @@ foreign import data UseEffect :: Type -> HookType
 -- |
 -- | ```purs
 -- | todos :: ReactElement
--- | todos = withHooks Hooks.do
+-- | todos = Hooks.component Hooks.do
 -- |   todos /\ setTodos <- useState []
 -- |
 -- |   useEffect do
@@ -41,7 +41,7 @@ useEffect runEffect = useEffect_ (ComponentName "UseEffect") identity unit $ con
 -- |
 -- | ```purs
 -- | view :: ReactElement
--- | view = withHooks Hooks.do
+-- | view = Hooks.component Hooks.do
 -- |   count /\ setCount <- useState 0
 -- |
 -- |   useEffect' count \c -> liftEffect $

--- a/src/Elmish/Hooks/UseRef.purs
+++ b/src/Elmish/Hooks/UseRef.purs
@@ -21,10 +21,10 @@ type UseRef el = UseState (Maybe el)
 -- |
 -- | ```purs
 -- | view :: ReactElement
--- | view = withHooks do
+-- | view = Hooks.component Hooks.do
 -- |   inputEl /\ inputRef <- useRef
 -- |   let onButtonClick = traverse_ (focus <<< HTMLInputElement.toHTMLElement) inputEl
--- |   pure $
+-- |   Hooks.pure $
 -- |     H.fragment
 -- |     [ H.input_ "form-control" { ref: inputRef, defaultValue: "" }
 -- |     , H.button_ "btn btn-primary" { onClick: onButtonClick } "Focus the input"

--- a/src/Elmish/Hooks/UseState.purs
+++ b/src/Elmish/Hooks/UseState.purs
@@ -20,7 +20,7 @@ foreign import data UseState :: Type -> HookType
 -- |
 -- | ```purs
 -- | view :: ReactElement
--- | view = withHooks Hooks.do
+-- | view = Hooks.component Hooks.do
 -- |   visible /\ setVisible <- useState false
 -- |   Hooks.pure $
 -- |     H.fragment

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -8,7 +8,7 @@ import Elmish.Enzyme (childAt, find, name, testElement, (>>))
 import Elmish.Enzyme as Enzyme
 import Elmish.Enzyme.Adapter as Adapter
 import Elmish.HTML.Styled as H
-import Elmish.Hooks (useEffect, useState, withHooks, (=/>), (==>))
+import Elmish.Hooks (useEffect, useState, (=/>), (==>))
 import Elmish.Hooks as Hooks
 import Elmish.Hooks.UseEffect (useEffect')
 import Test.Spec (Spec, describe, it)
@@ -32,30 +32,30 @@ spec = do
         _ <- useState ""
         Hooks.pure $ H.div "" "content"
 
-      withHooksComponent = withHooks component
+      hooksComponent = Hooks.component component
 
       wrappedComponent = H.div ""
-        [ H.div "with-hooks-1-parent" $ withHooks component
-        , H.div "with-hooks-2-parent" $ withHooks component
-        , H.div "with-hooks-3-parent" withHooksComponent
-        , H.div "with-hooks-4-parent" withHooksComponent
+        [ H.div "component-1-parent" $ Hooks.component component
+        , H.div "component-2-parent" $ Hooks.component component
+        , H.div "component-3-parent" hooksComponent
+        , H.div "component-4-parent" hooksComponent
         ]
 
-    describe "withHooks" do
+    describe "component" do
       it "has a unique name when used twice" $
         testElement wrappedComponent do
-          withHooks1Name <- find ".with-hooks-1-parent" >> childAt 0 >> name
-          withHooks2Name <- find ".with-hooks-2-parent" >> childAt 0 >> name
-          withHooks1Name `shouldContain` "WithHooks"
-          withHooks2Name `shouldContain` "WithHooks"
-          withHooks1Name `shouldNotEqual` withHooks2Name
+          component1Name <- find ".component-1-parent" >> childAt 0 >> name
+          component2Name <- find ".component-2-parent" >> childAt 0 >> name
+          component1Name `shouldContain` "HooksComponent"
+          component2Name `shouldContain` "HooksComponent"
+          component1Name `shouldNotEqual` component2Name
 
-      it "has the same when same reference used twice" $
+      it "has the same name when same reference used twice" $
         testElement wrappedComponent do
-          withHooks3Name <- find ".with-hooks-3-parent" >> childAt 0 >> name
-          withHooks4Name <- find ".with-hooks-4-parent" >> childAt 0 >> name
-          withHooks3Name `shouldContain` "WithHooks"
-          withHooks3Name `shouldEqual` withHooks4Name
+          component3Name <- find ".component-3-parent" >> childAt 0 >> name
+          component4Name <- find ".component-4-parent" >> childAt 0 >> name
+          component3Name `shouldContain` "HooksComponent"
+          component3Name `shouldEqual` component4Name
 
     describe "withHook" do
       let
@@ -72,13 +72,13 @@ spec = do
 
       it "has a unique name when used twice" $
         testElement wrappedWithHookComponent do
-          withHooks1Name <- find ".with-hook-1-parent" >> childAt 0 >> name
-          withHooks2Name <- find ".with-hook-2-parent" >> childAt 0 >> name
-          withHooks1Name `shouldContain` "WithHook"
-          withHooks2Name `shouldContain` "WithHook"
-          withHooks1Name `shouldNotEqual` withHooks2Name
+          withHook1Name <- find ".with-hook-1-parent" >> childAt 0 >> name
+          withHook2Name <- find ".with-hook-2-parent" >> childAt 0 >> name
+          withHook1Name `shouldContain` "WithHook"
+          withHook2Name `shouldContain` "WithHook"
+          withHook1Name `shouldNotEqual` withHook2Name
 
-      it "has the same when same reference used twice" $
+      it "has the same name when same reference used twice" $
         testElement wrappedWithHookComponent do
           withHook3Name <- find ".with-hook-3-parent" >> childAt 0 >> name
           withHook4Name <- find ".with-hook-4-parent" >> childAt 0 >> name
@@ -100,13 +100,13 @@ spec = do
 
       it "has a unique name when used twice" $
         testElement wrappedWithHookComponent do
-          withHooks1Name <- find ".with-hook-1-parent" >> childAt 0 >> name
-          withHooks2Name <- find ".with-hook-2-parent" >> childAt 0 >> name
-          withHooks1Name `shouldContain` "WithHookCurried"
-          withHooks2Name `shouldContain` "WithHookCurried"
-          withHooks1Name `shouldNotEqual` withHooks2Name
+          withHook1Name <- find ".with-hook-1-parent" >> childAt 0 >> name
+          withHook2Name <- find ".with-hook-2-parent" >> childAt 0 >> name
+          withHook1Name `shouldContain` "WithHookCurried"
+          withHook2Name `shouldContain` "WithHookCurried"
+          withHook1Name `shouldNotEqual` withHook2Name
 
-      it "has the same when same reference used twice" $
+      it "has the same name when same reference used twice" $
         testElement wrappedWithHookComponent do
           withHook3Name <- find ".with-hook-3-parent" >> childAt 0 >> name
           withHook4Name <- find ".with-hook-4-parent" >> childAt 0 >> name


### PR DESCRIPTION
This renames `withHooks` -> `component`, which is consistent with the other hook libraries out there and lends itself to qualified use. @fsoikin, curious whether you think `withHook` and `withHookCurried` should change. Maybe doesn’t matter since we encourage not using the named versions? Also, still have to update the changelog. I want to wait to update the version since this isn’t super important, though.