### PR TITLE
Update README to match new event handler syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.1
+
+### Changed
+
+- upgraded to Elmish 0.9.1
+
 ## 0.7.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ useMousePosition className =
     , update: \_ pos -> pure pos
     , view: \pos dispatch ->
         H.div_ className
-          { onMouseMove: unsafeCoerce $ mkEffectFn1 \(event :: { clientX :: Number, clientY :: Number, currentTarget :: HTMLElement }) -> do
+          { onMouseMove: E.handleEffect \(E.MouseEvent event) -> do
               { top, left, width, height } <- getBoundingClientRect event.currentTarget
               let
                 x = event.clientX - left
@@ -81,7 +81,7 @@ If you’re only using a single hook, sometimes it might be more concise to use 
 ```purs
 myInput :: ReactElement
 myInput = useState "" =/> \name setName ->
-  H.input_ "" { value: name, onChange: setName <?| eventTargetValue }
+  H.input_ "" { value: name, onChange: setName <| E.inputText }
 ```
 
 ### Examples

--- a/packages.dhall
+++ b/packages.dhall
@@ -3,5 +3,5 @@ let upstream =
         sha256:4949f9f5c3626ad6a83ea6b8615999043361f50905f736bc4b7795cba6251927
 
 in  upstream
-  with elmish.version = "v0.9.0"
+  with elmish.version = "v0.9.1"
   with elmish-html.version = "v0.8.0"


### PR DESCRIPTION
After publishing a new version on Pursuit, I realized I forgot to update the README, which features a code snippet with an event handler 🤦 